### PR TITLE
Fix all short stops being hit

### DIFF
--- a/gemini/engine.py
+++ b/gemini/engine.py
@@ -59,7 +59,7 @@ class backtest():
                                 p.stop_adjust(today['close'])
 
                 if p.type == "short":
-                    if p.stop_hit(today['high']):
+                    if p.stop_hit(today['high']) and p.stop_loss != 0:
                         self.account.close_position(p, 1.0, today['high'])
                     else:
                         if p.trailing_stop:


### PR DESCRIPTION
Stops are auto-set to 0, as a result, short stops will always be "hit" when a stop_loss is not manually set. 